### PR TITLE
feat: highlight faang-tier research

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <meta name="color-scheme" content="dark light" />
   <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
   <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
-  <meta name="description" content="ProofX — proof-grade ML/Python engines for verification. Deterministic portfolios, entropy-guided search, and audit-grade observability around your prover stack." />
+  <meta name="description" content="ProofX — proof-grade ML/Python engines for verification. Deterministic portfolios, entropy-guided search, audit-grade observability around your prover stack, and FAANG-tier research output." />
   <link rel="canonical" href="https://www.proofx.org/" />
 
   <title>ProofX — proof-grade ML/Python engines</title>
@@ -21,7 +21,7 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="ProofX — proof-grade ML/Python engines" />
-  <meta property="og:description" content="Deterministic solvers, entropy-driven search, and operator-grade observability — the fastest path from conjecture to verifiable evidence." />
+  <meta property="og:description" content="Deterministic solvers, entropy-driven search, and operator-grade observability — the fastest path from conjecture to verifiable evidence, built for FAANG-tier research output." />
   <meta property="og:url" content="https://www.proofx.org/" />
   <meta property="og:site_name" content="ProofX" />
   <meta property="og:image" content="https://www.proofx.org/assets/og.png" />
@@ -29,7 +29,7 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="ProofX — proof-grade ML/Python engines" />
-  <meta name="twitter:description" content="Deterministic portfolios, entropy-guided search, and audit-grade observability." />
+  <meta name="twitter:description" content="Deterministic portfolios, entropy-guided search, audit-grade observability, and FAANG-tier research output." />
   <meta name="twitter:image" content="https://www.proofx.org/assets/og.png" />
 
   <!-- Structured data -->
@@ -65,6 +65,7 @@
       <nav class="nav__links" role="navigation" aria-label="Primary">
         <a href="#vision">Vision</a>
         <a href="#engines">Engines</a>
+        <a href="#research">Research</a>
         <a href="https://docs.proofx.org" target="_blank" rel="noopener">Docs</a>
         <a href="#faq">FAQ</a>
         <a href="#contact">Contact</a>
@@ -79,7 +80,7 @@
         <h1 id="hero-title" class="hero__h1">Proof-grade ML/Python engines.</h1>
         <p class="hero__sub">
           Deterministic solvers, entropy-driven search, and operator-grade observability — the fastest path
-          from conjecture to verifiable evidence.
+          from conjecture to verifiable evidence, built for FAANG-tier research output.
         </p>
 
         <!-- Simplified primary actions: white buttons only (Partner, Invest, Cases) -->
@@ -226,6 +227,20 @@
         <p class="muted small">
           Deep-dives with diagrams and APIs at <a href="https://engine.proofx.org" target="_blank" rel="noopener">engine.proofx.org</a>.
         </p>
+      </div>
+    </section>
+
+    <!-- ================================= RESEARCH ======================== -->
+    <section id="research" class="section" aria-labelledby="research-title">
+      <div class="container card">
+        <h2 id="research-title">Research</h2>
+        <p>ProofX operates at FAANG-tier research velocity, delivering peer-reviewed work and open-source benchmarks.</p>
+        <ul class="bullets bullets--tight">
+          <li><strong>Peer-reviewed output:</strong> publications at top ML and formal methods venues.</li>
+          <li><strong>Open benchmarks:</strong> reproducible datasets and transparent leaderboards.</li>
+          <li><strong>Industry collaborations:</strong> joint projects with leading tech labs and universities.</li>
+        </ul>
+        <p class="muted">Browse the evolving bibliography at <a href="https://press.proofx.org" target="_blank" rel="noopener">press.proofx.org</a>.</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- emphasize FAANG-tier research output in SEO tags and hero copy
- add Research nav link and section showcasing publications and collaborations

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aa0b41cc83289c583893f601b9ed