### PR TITLE
Replace show more buttons with icon toggles and update quantum section

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,11 +53,11 @@
     "url": "https://www.proofx.org/",
     "logo": "https://www.proofx.org/assets/favicon-32x32.png",
     "sameAs": [
-      "https://vision.proofx.org",
-      "https://engine.proofx.org",
-      "https://docs.proofx.org",
-      "https://press.proofx.org",
-      "https://cases.proofx.org"
+      "https://www.proofx.org/vision",
+      "https://www.proofx.org/engines",
+      "https://www.proofx.org/docs",
+      "https://www.proofx.org/press",
+      "https://www.proofx.org/cases"
     ]
   }
   </script>
@@ -102,6 +102,31 @@
     .btn.btn--white:hover { filter: brightness(.98); }
     .btn.btn--blue  { background: #0A66FF; color: #fff; }
     .btn-row { display:flex; gap:.5rem; margin-top:1rem; flex-wrap:wrap; }
+
+    .btn.btn--icon {
+      background: none;
+      border: none;
+      cursor: pointer;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 5px;
+      padding: 8px;
+      width: 32px;
+      height: 32px;
+    }
+
+    .btn.btn--icon span {
+      display: block;
+      height: 2px;
+      width: 20px;
+      background: currentColor;
+      border-radius: 2px;
+    }
+
+    .btn.btn--icon.open span:nth-child(2) { opacity: 0; }
+    .btn.btn--icon.open span:nth-child(1) { transform: rotate(45deg) translateY(6px); }
+    .btn.btn--icon.open span:nth-child(3) { transform: rotate(-45deg) translateY(-6px); }
 
     /* Contact */
     .contact__actions .btn { margin-right: .5rem; margin-bottom: .5rem; }
@@ -193,17 +218,17 @@
       </button>
 
       <nav class="nav__links" role="navigation" aria-label="Primary">
-        <a href="https://vision.proofx.org">Vision</a>
-        <a href="https://engine.proofx.org">Engines</a>
-        <a href="https://quantum.proofx.org">Quantum</a>
-        <a href="https://collatzx.proofx.org">CollatzX</a>
-        <a href="https://dossier.proofx.org">Dossier</a>
-        <a href="https://findings.proofx.org">Findings</a>
-        <a href="https://research.proofx.org">Research</a>
-        <a href="https://docs.proofx.org" target="_blank" rel="noopener">Docs</a>
-        <a href="https://faq.proofx.org">FAQ</a>
-        <a href="https://founder.proofx.org">Founder</a>
-        <a href="https://contact.proofx.org">Contact</a>
+        <a href="/vision">Vision</a>
+        <a href="/engines">Engines</a>
+        <a href="/quantum">Quantum</a>
+        <a href="/conjectures/collatzx">CollatzX</a>
+        <a href="/dossier">Dossier</a>
+        <a href="/findings">Findings</a>
+        <a href="/research">Research</a>
+        <a href="/docs" target="_blank" rel="noopener">Docs</a>
+        <a href="/faq">FAQ</a>
+        <a href="/founder">Founder</a>
+        <a href="/contact">Contact</a>
       </nav>
     </div>
   </header>
@@ -221,7 +246,7 @@
         <div class="hero__actions" role="group" aria-label="Primary actions">
           <a class="btn btn--white btn--lg btn--pill" href="mailto:alkindi.proofx@gmail.com?subject=ProofX%20%E2%80%94%20Partner">Partner</a>
           <a class="btn btn--white btn--lg btn--pill" href="mailto:alkindi.proofx@gmail.com?subject=ProofX%20%E2%80%94%20Invest">Invest</a>
-          <a class="btn btn--white btn--lg btn--pill" href="https://cases.proofx.org" target="_blank" rel="noopener">Cases</a>
+          <a class="btn btn--white btn--lg btn--pill" href="/cases" target="_blank" rel="noopener">Cases</a>
         </div>
       </div>
     </section>
@@ -253,145 +278,149 @@
           <article class="card engine">
             <h3>CollatzX</h3>
             <p>Parity-block descent, excursion envelopes, and witness harvesting for 3n+1 dynamics.</p>
-            <a class="engine__link" href="https://collatzx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/collatzx">Explore engine →</a>
           </article>
 
           <!-- 2 -->
           <article class="card engine">
             <h3>RiemannX</h3>
             <p>Zero statistics, GUE conformity checks, and explicit formula diagnostics on ζ(s).</p>
-            <a class="engine__link" href="https://riemannx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/riemannx">Explore engine →</a>
           </article>
 
           <!-- 3 -->
           <article class="card engine">
             <h3>GoldbachX</h3>
             <p>Sieve portfolios, parity constraints, and counterexample mining on even decompositions.</p>
-            <a class="engine__link" href="https://goldbachx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/goldbachx">Explore engine →</a>
           </article>
 
           <!-- 4 -->
           <article class="card engine hidden">
             <h3>TwinPrimeX</h3>
             <p>Prime gap analytics, parity restrictions, and admissible k-tuple scorecards.</p>
-            <a class="engine__link" href="https://twinprimex.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/twinprimex">Explore engine →</a>
           </article>
 
           <!-- 5 -->
           <article class="card engine hidden">
             <h3>BirchSwinnertonDyerX</h3>
             <p>L-function traces, rank heuristics, descent ladders over elliptic curve families.</p>
-            <a class="engine__link" href="https://bsdx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/bsdx">Explore engine →</a>
           </article>
 
           <!-- 6 -->
           <article class="card engine hidden">
             <h3>ABCX</h3>
             <p>Radical bounds, quality metrics, and counterexample stress tests across integer triples.</p>
-            <a class="engine__link" href="https://abcx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/abcx">Explore engine →</a>
           </article>
 
           <!-- 7 -->
           <article class="card engine hidden">
             <h3>BealX</h3>
             <p>Exponent coprimality, prime factor coverage, and exhaustive search with replay manifests.</p>
-            <a class="engine__link" href="https://bealx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/bealx">Explore engine →</a>
           </article>
 
           <!-- 8 -->
           <article class="card engine hidden">
             <h3>ErdosStrausX</h3>
             <p>Unit-fraction decompositions of 4/n with structured residue families and witness export.</p>
-            <a class="engine__link" href="https://erdosstrausx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/erdosstrausx">Explore engine →</a>
           </article>
 
           <!-- 9 -->
           <article class="card engine hidden">
             <h3>LegendreX</h3>
             <p>Square-gap search between consecutive squares with parity and density heuristics.</p>
-            <a class="engine__link" href="https://legendrex.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/legendrex">Explore engine →</a>
           </article>
 
           <!-- 10 -->
           <article class="card engine hidden">
             <h3>PolignacX</h3>
             <p>Even-gap prime constellations with admissible pattern scoring and density tracking.</p>
-            <a class="engine__link" href="https://polignacx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/polignacx">Explore engine →</a>
           </article>
 
           <!-- 11 -->
           <article class="card engine hidden">
             <h3>CramérX</h3>
             <p>Probabilistic prime-gap envelopes, extreme-value probes, and falsifiability checks.</p>
-            <a class="engine__link" href="https://cramerx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/cramerx">Explore engine →</a>
           </article>
 
           <!-- 12 -->
           <article class="card engine hidden">
             <h3>SchanuelX</h3>
             <p>Transcendence heuristics with exponential-algebraic independence diagnostics.</p>
-            <a class="engine__link" href="https://schanuelx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/schanuelx">Explore engine →</a>
           </article>
 
           <!-- 13 -->
           <article class="card engine hidden">
             <h3>OddPerfectX</h3>
             <p>Constraint drives on hypothetical odd perfect numbers with factor-structure pruning.</p>
-            <a class="engine__link" href="https://oddperfectx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/oddperfectx">Explore engine →</a>
           </article>
 
           <!-- 14 -->
           <article class="card engine hidden">
             <h3>GoodsteinX</h3>
             <p>Ordinal descent simulations, fast-growing hierarchy bounds, and certificate export.</p>
-            <a class="engine__link" href="https://goodsteinx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/goodsteinx">Explore engine →</a>
           </article>
 
           <!-- 15 -->
           <article class="card engine hidden">
             <h3>ParisHarringtonX</h3>
             <p>Independence demonstrations with finite model tests and large-number growth tracking.</p>
-            <a class="engine__link" href="https://parisharringtonx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/parisharringtonx">Explore engine →</a>
           </article>
 
           <!-- 16 -->
           <article class="card engine hidden">
             <h3>ContinuumX</h3>
             <p>Model explorations around CH with forcing-scheme simulators and witness registries.</p>
-            <a class="engine__link" href="https://continuumx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/continuumx">Explore engine →</a>
           </article>
 
           <!-- 17 -->
           <article class="card engine hidden">
             <h3>ChaitinOmegaX</h3>
             <p>Algorithmic randomness probes with prefix-free complexity estimators.</p>
-            <a class="engine__link" href="https://omegax.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/omegax">Explore engine →</a>
           </article>
 
           <!-- 18 -->
           <article class="card engine hidden">
             <h3>PvsNPX</h3>
             <p>Lower-bound scaffolds, circuit-reduction harnesses, and oracle stress benches.</p>
-            <a class="engine__link" href="https://pvsnpx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/pvsnpx">Explore engine →</a>
           </article>
 
           <!-- 19 -->
           <article class="card engine hidden">
             <h3>NavierStokesX</h3>
             <p>Regularity/finite-time blow-up diagnostics over discretized flows with replay</p>
-            <a class="engine__link" href="https://navierstokesx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/navierstokesx">Explore engine →</a>
           </article>
 
           <!-- 20 -->
           <article class="card engine hidden">
             <h3>YangMillsX</h3>
             <p>Mass gap heuristics with lattice approximations and spectral gap estimators.</p>
-            <a class="engine__link" href="https://yangmillsx.proofx.org">Explore engine →</a>
+            <a class="engine__link" href="/conjectures/yangmillsx">Explore engine →</a>
           </article>
         </div>
 
         <div class="btn-row" role="group" aria-label="Engines list controls">
-          <button id="engines-show-more" class="btn btn--white btn--pill" aria-controls="engines-grid" aria-expanded="false">Show more</button>
+          <button id="engines-show-more" class="btn btn--icon" aria-label="Show more" aria-controls="engines-grid" aria-expanded="false">
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
           <button id="engines-show-less" class="btn btn--blue btn--pill hidden" aria-controls="engines-grid" aria-expanded="true">Show less</button>
         </div>
         <div id="engines-live" class="sr-only" aria-live="polite"></div>
@@ -405,7 +434,7 @@
         <p class="muted">ProofX Quantum engines leverage quantum computing to accelerate verification of complex conjectures with quantum advantage.</p>
 
         <div class="quantum-conjecture">
-          <h3>CollatzZ Quantum Engine</h3>
+          <h3>CollatzX Quantum Engine</h3>
           <p>Quantum-enhanced verification of the Collatz conjecture using superposition and quantum parallelism.</p>
           <div class="test-cases-grid">
             <div class="test-case">
@@ -459,11 +488,11 @@
               </ul>
             </div>
           </div>
-          <a class="engine__link" href="https://quantum.proofx.org/collatzz">Explore Quantum Engine →</a>
+          <a class="engine__link" href="/quantum/collatzx">Explore Quantum Engine →</a>
         </div>
 
         <div class="quantum-conjecture">
-          <h3>ReicmannX Quantum Engine</h3>
+          <h3>RiemannX Quantum Engine</h3>
           <p>Quantum algorithms for verifying properties of the Riemann zeta function and hypothesis.</p>
           <div class="test-cases-grid">
             <div class="test-case">
@@ -517,7 +546,7 @@
               </ul>
             </div>
           </div>
-          <a class="engine__link" href="https://quantum.proofx.org/reicmannx">Explore Quantum Engine →</a>
+          <a class="engine__link" href="/quantum/riemannx">Explore Quantum Engine →</a>
         </div>
 
         <div class="quantum-conjecture">
@@ -575,12 +604,60 @@
               </ul>
             </div>
           </div>
-          <a class="engine__link" href="https://quantum.proofx.org/godelx">Explore Quantum Engine →</a>
+          <a class="engine__link" href="/quantum/godelx">Explore Quantum Engine →</a>
         </div>
 
         <div class="quantum-conjecture">
           <h3>GoldbachX Quantum Engine</h3>
-          <p class="coming-soon">Quantum algorithm for verifying the Goldbach conjecture - Coming Soon</p>
+          <p>Quantum strategies for verifying the Goldbach conjecture with number-theoretic amplitude estimation.</p>
+          <div class="test-cases-grid">
+            <div class="test-case">
+              <h4>CoreLogic Tests</h4>
+              <ul>
+                <li>Quantum superposition of even integers</li>
+                <li>Prime pair generation via quantum circuits</li>
+                <li>Amplitude amplification for prime pair search</li>
+                <li>Entanglement for parity conservation</li>
+              </ul>
+            </div>
+            <div class="test-case">
+              <h4>ProofDiagnostics</h4>
+              <ul>
+                <li>Quantum state verification of prime outputs</li>
+                <li>Error mitigation on modular addition</li>
+                <li>Circuit depth analysis for prime generation</li>
+                <li>Resource estimation for large even bounds</li>
+              </ul>
+            </div>
+            <div class="test-case">
+              <h4>ConjectureBenchmarks</h4>
+              <ul>
+                <li>Even range coverage vs classical search</li>
+                <li>Quantum speedup measurement</li>
+                <li>Scalability with qubit count</li>
+                <li>Noise tolerance in prime detection</li>
+              </ul>
+            </div>
+            <div class="test-case">
+              <h4>SymbolicGenerators</h4>
+              <ul>
+                <li>Quantum circuit templates for prime testing</li>
+                <li>Variational circuits for prime pair heuristics</li>
+                <li>Automated symbolic reduction of prime sums</li>
+                <li>Hybrid classical-quantum prime synthesis</li>
+              </ul>
+            </div>
+            <div class="test-case">
+              <h4>InferenceLayer</h4>
+              <ul>
+                <li>Quantum Bayesian confidence on Goldbach pairs</li>
+                <li>Amplitude estimation for proof bounds</li>
+                <li>Quantum ML classification of valid pairs</li>
+                <li>Reinforcement learning for search strategy</li>
+              </ul>
+            </div>
+          </div>
+          <a class="engine__link" href="/quantum/goldbachx">Explore Quantum Engine →</a>
         </div>
 
         <div class="quantum-conjecture">
@@ -623,7 +700,7 @@
         <p class="muted">Bibliography and artifacts are curated on press and docs hubs.</p>
 
         <div role="group" aria-label="Research actions">
-          <a class="btn btn--primary btn--pill" href="https://research.proofx.org/assets/proofx-overview.pdf" download>
+          <a class="btn btn--primary btn--pill" href="/research/assets/proofx-overview.pdf" download>
             Download overview (PDF)
           </a>
         </div>
@@ -636,7 +713,7 @@
         <h2 id="collatzx-title">CollatzX</h2>
         <p class="muted">Overview available in the lab brief. Detailed materials provided on request.</p>
         <div role="group" aria-label="CollatzX actions">
-          <a class="btn btn--primary btn--pill" href="https://collatzx.proofx.org/assets/collatzx.pdf" download>Download overview (PDF)</a>
+          <a class="btn btn--primary btn--pill" href="/conjectures/collatzx/assets/collatzx.pdf" download>Download overview (PDF)</a>
         </div>
       </div>
     </section>
@@ -670,7 +747,7 @@
               The red point marks the maximum observed length; reproducibility demonstrates the
               engine's anomaly-detection rigor.
             </p>
-            <a class="btn btn--pill btn--white small" href="https://findings.proofx.org/assets/collatz_plot.png" download>Download figure (PNG)</a>
+            <a class="btn btn--pill btn--white small" href="/findings/assets/collatz_plot.png" download>Download figure (PNG)</a>
           </div>
 
           <figure class="finding-visual">
@@ -679,7 +756,7 @@
               <!-- <source srcset="/assets/collatz_plot.webp" type="image/webp"> -->
               <img
                 class="findings__img"
-                src="https://findings.proofx.org/assets/collatz_plot.png"
+                src="/findings/assets/collatz_plot.png"
                 alt="CollatzX trajectory: sequence length vs. starting value (log scale); red point marks the maximum."
                 loading="eager"
                 fetchpriority="high"
@@ -700,7 +777,7 @@
               <p class="muted small">Brief note about what this visual demonstrates.</p>
             </div>
             <figure class="finding-visual">
-              <img src="https://findings.proofx.org/assets/finding2.png" alt="Finding 2 visualization"
+              <img src="/findings/assets/finding2.png" alt="Finding 2 visualization"
                   loading="lazy" decoding="async" />
               <figcaption class="muted xsmall">Fig. 2 — Short caption.</figcaption>
             </figure>
@@ -712,7 +789,7 @@
               <p class="muted small">One-sentence takeaway for the reader.</p>
             </div>
             <figure class="finding-visual">
-              <img src="https://findings.proofx.org/assets/finding3.png" alt="Finding 3 visualization"
+              <img src="/findings/assets/finding3.png" alt="Finding 3 visualization"
                   loading="lazy" decoding="async" />
               <figcaption class="muted xsmall">Fig. 3 — Short caption.</figcaption>
             </figure>
@@ -724,7 +801,7 @@
               <p class="muted small">Key diagnostic or anomaly captured here.</p>
             </div>
             <figure class="finding-visual">
-              <img src="https://findings.proofx.org/assets/finding4.png" alt="Finding 4 visualization"
+              <img src="/findings/assets/finding4.png" alt="Finding 4 visualization"
                   loading="lazy" decoding="async" />
               <figcaption class="muted xsmall">Fig. 4 — Short caption.</figcaption>
             </figure>
@@ -736,7 +813,7 @@
               <p class="muted small">Short description to anchor the plot.</p>
             </div>
             <figure class="finding-visual">
-              <img src="https://findings.proofx.org/assets/finding5.png" alt="Finding 5 visualization"
+              <img src="/findings/assets/finding5.png" alt="Finding 5 visualization"
                   loading="lazy" decoding="async" />
               <figcaption class="muted xsmall">Fig. 5 — Short caption.</figcaption>
             </figure>
@@ -744,8 +821,12 @@
         </div>
 
         <div class="btn-row" role="group" aria-label="Findings controls">
-          <button id="findings-show-more" class="btn btn--white btn--pill"
-                  aria-controls="findings-grid" aria-expanded="false">Show more</button>
+          <button id="findings-show-more" class="btn btn--icon" aria-label="Show more"
+                  aria-controls="findings-grid" aria-expanded="false">
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
           <button id="findings-show-less" class="btn btn--blue btn--pill hidden"
                   aria-controls="findings-grid" aria-expanded="false">Show less</button>
         </div>
@@ -904,7 +985,11 @@
         </div>
 
         <div class="btn-row" role="group" aria-label="FAQ controls">
-          <button id="faq-show-more" class="btn btn--white btn--pill" aria-controls="faq-list" aria-expanded="false">Show more</button>
+          <button id="faq-show-more" class="btn btn--icon" aria-label="Show more" aria-controls="faq-list" aria-expanded="false">
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
           <button id="faq-show-less" class="btn btn--blue btn--pill hidden" aria-controls="faq-list" aria-expanded="true">Show less</button>
         </div>
         <div id="faq-live" class="sr-only" aria-live="polite"></div>
@@ -989,21 +1074,21 @@
     <div class="container footer__inner">
       <span class="muted">© 2025 ProofX</span>
       <nav class="footer__links" aria-label="Footer">
-        <a href="https://vision.proofx.org">Vision</a>
-        <a href="https://mission.proofx.org">Mission</a>
-        <a href="https://support.proofx.org">Support</a>
-        <a href="https://about.proofx.org">About</a>
-        <a href="https://founder.proofx.org">Founder</a>
-        <a href="https://contact.proofx.org">Contact</a>
-        <a href="https://partner.proofx.org">Partner</a>
-        <a href="https://careers.proofx.org">Careers</a>
-        <a href="https://media.proofx.org">Media</a>
-        <a href="https://investors.proofx.org">Investors</a>
-        <a href="https://community.proofx.org">Community</a>
-        <a href="https://roadmap.proofx.org">Roadmap</a>
-        <a href="https://demo.proofx.org">Demo</a>
-        <a href="https://security.proofx.org">Security</a>
-        <a href="https://findings.proofx.org">Findings</a>
+        <a href="/vision">Vision</a>
+        <a href="/mission">Mission</a>
+        <a href="/support">Support</a>
+        <a href="/about">About</a>
+        <a href="/founder">Founder</a>
+        <a href="/contact">Contact</a>
+        <a href="/partner">Partner</a>
+        <a href="/careers">Careers</a>
+        <a href="/media">Media</a>
+        <a href="/investors">Investors</a>
+        <a href="/community">Community</a>
+        <a href="/roadmap">Roadmap</a>
+        <a href="/demo">Demo</a>
+        <a href="/security">Security</a>
+        <a href="/findings">Findings</a>
       </nav>
       <a class="to-top" href="#top" aria-label="Back to top">↑</a>
     </div>
@@ -1081,6 +1166,7 @@
             btnLess.classList.remove('hidden');
             btnMore.setAttribute('aria-expanded', String(remain === 0));
             announce(remain === 0 ? 'All items shown.' : `${remain} remaining.`);
+            btnMore.classList.toggle('open');
           });
         }
 
@@ -1094,6 +1180,7 @@
             announce('Items collapsed.');
             // Move focus for accessibility
             btnMore.focus();
+            btnMore.classList.remove('open');
           });
         }
 


### PR DESCRIPTION
## Summary
- Switch all "Show more" buttons to minimalist hamburger icons with animation.
- Unify links under proofx.org paths and expand GoldbachX quantum engine with test cases.
- Add CSS and JS to support icon buttons and toggle states.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b88af0e928832894cd78460d413adc